### PR TITLE
Add "Compact Aligned" message view mode.

### DIFF
--- a/app/lib/server/startup/settings.js
+++ b/app/lib/server/startup/settings.js
@@ -448,6 +448,10 @@ settings.addGroup('Accounts', function() {
 					key: 2,
 					i18nLabel: 'Compact',
 				},
+				{
+					key: 3,
+					i18nLabel: 'Compact Aligned',
+				},
 			],
 			public: true,
 			i18nLabel: 'MessageBox_view_mode',

--- a/app/theme/client/imports/components/messages.css
+++ b/app/theme/client/imports/components/messages.css
@@ -310,3 +310,125 @@
 		}
 	}
 }
+
+.compact-aligned {
+	& .message {
+		min-height: 26px;
+		padding: 5px 15px 5px 37px;
+
+		&.sequential {
+			& .thumb:not(.thumb-small),
+			& .user {
+				display: inline-block;
+			}
+
+			& .title {
+				position: relative;
+				left: 0;
+
+				text-align: left;
+				justify-content: initial;
+
+				& .edited {
+					display: inline-block;
+				}
+			}
+		}
+
+		& .attachment {
+			& .attachment-title > a {
+				font-size: 0.9em;
+			}
+
+			& .attachment-author img {
+				border-radius: 2px;
+			}
+
+			& .inline-image img {
+				max-height: 100px;
+			}
+
+			& .inline-video {
+				max-height: 150px;
+			}
+		}
+
+		& .attachment-spacer {
+			flex: 0 0 10%;
+
+			min-width: 3.5rem;
+			max-width: 10rem;
+		}
+
+		& blockquote iframe {
+			width: 266px;
+			height: 150px;
+		}
+
+		& .message-body-wrapper {
+			display: flex;
+			align-items: flex-start;
+
+			& .time {
+				margin-left: auto;
+			}
+		}
+
+		& .body {
+			display: inline;
+
+			max-width: 100%;
+			padding-right: 15px;
+
+			word-wrap: anywhere;
+		}
+
+		& .title {
+
+			overflow: hidden;
+			flex: 0 0 10%;
+
+			min-width: 3.5rem;
+			max-width: 10rem;
+
+			& .avatar-image {
+				border-radius: 2px;
+			}
+
+			& .role-tag {
+				display: none;
+			}
+
+			& .edited {
+				margin-left: 4px;
+
+				& .icon-pencil::before {
+					margin-right: 0;
+				}
+			}
+		}
+
+		& .user {
+			overflow: hidden;
+
+			width: 100%;
+			min-width: 0;
+
+			white-space: nowrap;
+			text-overflow: ellipsis;
+		}
+
+		& .thumb {
+			left: 10px;
+
+			width: 20px;
+			height: 20px;
+			margin-left: 0;
+
+			& .avatar {
+				width: 20px;
+				height: 20px;
+			}
+		}
+	}
+}

--- a/app/threads/client/flextab/thread.html
+++ b/app/threads/client/flextab/thread.html
@@ -1,7 +1,7 @@
 <template name="thread">
 	<section class="contextual-bar__content flex-tab threads dropzone {{dragAndDrop}} {{hideUsername}}">
 		<div class="dropzone-overlay {{isDropzoneDisabled}} background-transparent-darkest color-content-background-color">{{_ dragAndDropLabel}}</div>
-		<div class="thread-list js-scroll-thread">
+		<div class="thread-list js-scroll-thread {{messageViewMode}}">
 			<ul class="thread">
 				{{# with messageContext}}
 				{{#if isLoading}}

--- a/app/threads/client/flextab/thread.js
+++ b/app/threads/client/flextab/thread.js
@@ -135,6 +135,11 @@ Template.thread.helpers({
 			onChange: () => instance.state.set('sendToChannel', !checked),
 		};
 	},
+	messageViewMode() {
+		const viewMode = getUserPreference(Meteor.userId(), 'messageViewMode');
+		const modes = ['', '', '', 'compact-aligned'];
+		return modes[viewMode] || modes[0];
+	},
 });
 
 

--- a/app/threads/client/threads.css
+++ b/app/threads/client/threads.css
@@ -8,7 +8,7 @@
 	display: block;
 }
 
-.message.sequential[data-tmid] > .message-body-wrapper > .title {
+.message.sequential[data-tmid] > .message-body-wrapper > .title:not(.compact-aligned) {
 	display: none;
 }
 
@@ -210,6 +210,33 @@
 		& .thread-replied {
 			flex-basis: 100%;
 		}
+	}
+}
+
+.compact-aligned {
+	& .thread-replied-spacer {
+		flex: 0 0 10%;
+
+		min-width: 3.5rem;
+		max-width: 10rem;
+	}
+
+	& .quote-spacer {
+		flex: 0 0 10%;
+
+		min-width: 3.5rem;
+		max-width: 10rem;
+	}
+
+	& .message > .thread-replied > .thumb {
+		position: relative;
+		left: 0;
+
+		margin-right: 4px;
+	}
+
+	& .thread-quote {
+		margin-left: 0;
 	}
 }
 

--- a/app/ui-message/client/message.html
+++ b/app/ui-message/client/message.html
@@ -3,6 +3,7 @@
 		{{#if isThreadReply}}
 			{{> messageThread parentMessage=parentMessage msg=msg tmid=msg.tmid class=bodyClass following=msg.following}}
 			<div class="thread-replied js-open-thread">
+				<div class="thread-replied-spacer"></div>
 				<button aria-label="{{msg.u.username}}" class="thumb user-card-message" data-username="{{msg.u.username}}">
 					{{> avatar username=msg.u.username}}
 				</button>
@@ -36,7 +37,7 @@
 				{{/if}}
 			{{/if}}
 			<div class="message-body-wrapper">
-				<div class="title border-component-color color-info-font-color">
+				<div class="title border-component-color color-info-font-color {{messageViewMode}}">
 					<button type="button" class="user user-card-message color-primary-font-color" data-username="{{msg.u.username}}" tabindex="1">
 						{{getName}}{{#if showUsername}} <span class="message-alias border-component-color color-info-font-color">@{{msg.u.username}}</span>{{/if}}
 					</button>
@@ -52,7 +53,7 @@
 					{{#if isBot}}
 						<span class="is-bot color-secondary-color border-component-color">{{_ "Bot"}}</span>
 					{{/if}}
-					<time class="time" title='{{date}} {{time}}' datetime='{{date}} {{time}}'>{{time}}</time>
+					{{#unless isCompactAligned}} <time class="time" title='{{date}} {{time}}' datetime='{{date}} {{time}}'>{{time}}</time>{{/unless}}
 					{{#if showTranslated}}
 						<span class="translated">
 							<i class="icon-language {{#if msg.autoTranslateFetching}}loading{{/if}}" title="{{_ "Translated"}}"></i>
@@ -105,8 +106,11 @@
 						{{> messageLocation location=msg.location}}
 					{{/if}}
 				</div>
+				{{#if isCompactAligned}}<time class="time" title='{{date}} {{time}}' datetime='{{date}} {{time}}'>{{time}}</time>{{/if}}
 			</div>
 
+			<div class="attachment-wrapper" style="display: flex;">
+			<div class="quote-spacer"></div>
 			{{#if hasOembed}}
 				{{#each msg.urls}}
 					{{injectMessage . ../msg}}
@@ -129,6 +133,7 @@
 			{{#if broadcast}}
 			 	{{> BroadCastMetric mid=msg._id username=msg.u.username replyBroadcast=actions.replyBroadcast }}
 			{{/if}}
+			</div>
 
 			{{#with readReceipt}}
 				<div class="read-receipt {{readByEveryone}}">

--- a/app/ui-message/client/message.js
+++ b/app/ui-message/client/message.js
@@ -11,7 +11,7 @@ import { normalizeThreadTitle } from '../../threads/client/lib/normalizeThreadTi
 import { MessageTypes, MessageAction } from '../../ui-utils/client';
 import { RoomRoles, UserRoles, Roles } from '../../models/client';
 import { Markdown } from '../../markdown/client';
-import { t, roomTypes } from '../../utils';
+import { t, roomTypes, getUserPreference } from '../../utils';
 import './messageThread';
 import { AutoTranslate } from '../../autotranslate/client';
 import { escapeHTML } from '../../../lib/escapeHTML';
@@ -430,6 +430,15 @@ Template.message.helpers({
 	isThreadReply() {
 		const { groupable, msg: { tmid, t, groupable: _groupable }, settings: { showreply } } = this;
 		return !(groupable === true || _groupable === true) && !!(tmid && showreply && (!t || t === 'e2e'));
+	},
+	messageViewMode() {
+		const viewMode = getUserPreference(Meteor.userId(), 'messageViewMode');
+		const modes = ['', '', '', 'compact-aligned'];
+		return modes[viewMode] || modes[0];
+	},
+	isCompactAligned() {
+		const viewMode = getUserPreference(Meteor.userId(), 'messageViewMode');
+		return viewMode === 3;
 	},
 	shouldHideBody() {
 		const { msg: { tmid, actionContext }, settings: { showreply }, context } = this;

--- a/app/ui-message/client/messageThread.html
+++ b/app/ui-message/client/messageThread.html
@@ -1,4 +1,6 @@
 <template name="messageThread">
+	<div class="quote-wrapper" style="display: flex;">
+	<div class="quote-spacer"></div>
 	<q role="button" title="{{_ "Open_thread"}}" class="thread-quote js-open-thread">
 		{{> icon icon="thread" block="thread-icons"}} <div class="thread-quote__message "><span class="message-body--unstyled">{{{parentMessage}}}</span></div>
 		{{# if following }}
@@ -11,4 +13,5 @@
 		</div>
 		{{/if}}
 	</q>
+	</div>
 </template>

--- a/app/ui/client/views/app/room.js
+++ b/app/ui/client/views/app/room.js
@@ -337,7 +337,7 @@ Template.roomOld.helpers({
 
 	messageViewMode() {
 		const viewMode = getUserPreference(Meteor.userId(), 'messageViewMode');
-		const modes = ['', 'cozy', 'compact'];
+		const modes = ['', 'cozy', 'compact', 'compact-aligned'];
 		return modes[viewMode] || modes[0];
 	},
 

--- a/client/views/account/preferences/PreferencesMessagesSection.js
+++ b/client/views/account/preferences/PreferencesMessagesSection.js
@@ -80,6 +80,7 @@ const PreferencesMessagesSection = ({ onChange, commitRef, ...props }) => {
 		[0, t('Normal')],
 		[1, t('Cozy')],
 		[2, t('Compact')],
+		[3, t('Compact Aligned')],
 	], [t]);
 
 	commitRef.current.messages = commit;


### PR DESCRIPTION
Adds a new message view mode that moves the timestamp to the end of the line and aligns the messages regardless of username length. Since it's not thoroughly tested, I added as a separate mode, this way people will be able to fall-back to the regular compact view if needed.

Probably not the cleanest HTML/CSS, but I didn't want to spend too much time on this :)

![rocketchat](https://user-images.githubusercontent.com/4402304/119527326-82a13a80-bd80-11eb-986e-4cd9927a7b35.png)
